### PR TITLE
Support group ID as receipient

### DIFF
--- a/octoprint_signalnotifier/__init__.py
+++ b/octoprint_signalnotifier/__init__.py
@@ -97,7 +97,11 @@ class SignalNotifierPlugin(octoprint.plugin.EventHandlerPlugin,
             return               
 
         # ./signal-cli -u +4915151111111 send -m "My first message from the CLI" +4915152222222
-        the_command = "%s -u %s send -m \"%s\" %s" % (path, sender, message, recipient)
+        # ./signal-cli -u +4915151111111 send -g <group_id> -m "My first message from the CLI to a group"
+        if recipient[:1] == "+":
+            the_command = "%s -u %s send -m \"%s\" %s" % (path, sender, message, recipient)
+        else:
+            the_command = "%s -u %s send -g %s -m \"%s\"" % (path, sender, recipient, message)
         self._logger.debug("Command plugin will run is: '%s'" % the_command)
         try:
             rc, osstdout = self.run_command(the_command)

--- a/octoprint_signalnotifier/templates/signalnotifier_settings.jinja2
+++ b/octoprint_signalnotifier/templates/signalnotifier_settings.jinja2
@@ -32,8 +32,10 @@
 		</div>
 	</div>
 
+	<p>{{ _('To send to an individual, the recipient should be the phone number beginning with a "+". To send to a group, enter the group ID') }}</p>
+
 	<h4>{{ _('Message Content') }}</h4>
-	
+
 	<p>{{ _('The template may contain the tags <code>{user}</code>, <code>{host}</code>, <code>{filename}</code>, <code>{elapsed_time}</code>.') }}</p>
 
 	<div class="control-group" title="{{ _('Content of notification email') }}">


### PR DESCRIPTION
The receipient field will accept a group ID. If the receipient begins
with a + then it is a phone number, if not then a group ID.
Group IDs can be found using `signal-cli listGroups`.