### PR TITLE
Use default branch of OctoPrint instead of devel

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ python:
   - "3.8"
 
 install:
-    - git clone -b devel --depth 1 https://github.com/foosel/OctoPrint.git
+    - git clone --depth 1 https://github.com/foosel/OctoPrint.git
     - cd OctoPrint && pip install -e . && cd -
     - pip install -r requirements-test.txt
     - pip install -e .


### PR DESCRIPTION
OctoPrint 1.4.0 with Python 3 has been released.